### PR TITLE
enable the annotateit.org bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ XYZ.iriscouch.com/store = DBNAME/_design/annouch/_rewrite
 ```
 [cors]
 headers = Accept, Origin, x-annotator-auth-token, Content-Type
-methods = PUT, POST, GET, OPTIONS
+methods = PUT, POST, GET, OPTIONS, DELETE
 origins = *
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,38 @@ Annouch is a CouchApp that can store annotations from [Annotator][1].
 
 [1]: http://okfnlabs.org/annotator/
 
+## use the annotateit.org Bookmarklet
+**1. create an account on annotateit.org**
+
+**2. Copy and configure (i used XYZ.iriscouch.com/store) the following code into a bookmarklet of your browser**
+
+```js
+javascript:(
+  function(a, b) {
+    a._annotatorConfig = {
+      auth: {
+        tokenUrl: "http://annotateit.org/api/token"
+      },
+      store: {
+        prefix: "http://YOUR_OWN_API_ENDPOINT"
+      },
+      tags: !0
+    }, s = b.body.appendChild(b.createElement("script")), s.language = "javascript", s.src = "http://assets.annotateit.org/bookmarklet/bootstrap.js"
+  }
+)(this,this.document);
+```
+**3. configure a vhost** (local.ini)
+```
+[vhosts]
+XYZ.iriscouch.com/store = DBNAME/_design/annouch/_rewrite
+```
+**4. enable CORS** (local.ini)
+```
+[cors]
+headers = Accept, Origin, x-annotator-auth-token, Content-Type
+methods = PUT, POST, GET, OPTIONS
+origins = *
+```
 
 License
 -------

--- a/commonjs/validate.js
+++ b/commonjs/validate.js
@@ -1,0 +1,73 @@
+// a library for validations
+// over time we expect to extract more helpers and move them here.
+exports.init = function(newDoc, oldDoc, userCtx, secObj) {
+  var v = {};
+  
+  v.forbidden = function(message) {    
+    throw({forbidden : message});
+  };
+
+  v.unauthorized = function(message) {
+    throw({unauthorized : message});
+  };
+
+  v.assert = function(should, message) {
+    if (!should) v.forbidden(message);
+  }
+  
+  v.isAdmin = function() {
+    if(userCtx.roles.indexOf('_admin') !== -1) {
+      return true; // a server admin
+    }
+    
+    if(secObj && secObj.admins && secObj.admins.names) {
+      if(secObj.admins.names.indexOf(userCtx.name) !== -1) {
+        return true; // database admin
+      }
+    }
+
+    if(secObj && secObj.admins && secObj.admins.roles) {
+      var db_roles = secObj.admins.roles;
+      for(var idx = 0; idx < userCtx.roles.length; idx++) {
+        var user_role = userCtx.roles[idx];
+        if(db_roles.indexOf(user_role) !== -1) {
+           return true; // role matches!
+        }
+      }
+    }
+
+    return false; // default to no admin
+  };
+  
+  v.isRole = function(role) {
+    return userCtx.roles.indexOf(role) != -1
+  };
+
+  v.require = function() {
+    for (var i=0; i < arguments.length; i++) {
+      var field = arguments[i];
+      message = "The '"+field+"' field is required.";
+      if (typeof newDoc[field] == "undefined") v.forbidden(message);
+    };
+  };
+
+  v.unchanged = function(field) {
+    if (oldDoc && oldDoc[field] != newDoc[field]) 
+      v.forbidden("You may not change the '"+field+"' field.");
+  };
+
+  v.matches = function(field, regex, message) {
+    if (!newDoc[field].match(regex)) {
+      message = message || "Format of '"+field+"' field is invalid.";
+      v.forbidden(message);    
+    }
+  };
+
+  // this ensures that the date will be UTC, parseable, and collate correctly
+  v.dateFormat = function(field) {
+    message = "Sorry, '"+field+"' is not a valid date format. Try: 2010-02-24T17:00:03.432Z";
+    v.matches(field, /\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}(\.\d*)?Z/, message);
+  }
+  
+  return v;
+};

--- a/lists/search.js
+++ b/lists/search.js
@@ -1,0 +1,17 @@
+function (head, req) {
+  var payload = {}
+    , rows = []
+    , row
+
+  start({'headers': {'Content-Type' : 'application/json'}, 'code' : 200})
+
+  while (row = getRow()) {
+    rows.push(row.doc)
+  }
+
+  payload.total = head.total_rows
+  payload.rows = rows
+  payload.offset = head.offset
+
+  send(JSON.stringify(payload))
+}

--- a/rewrites.json
+++ b/rewrites.json
@@ -1,5 +1,15 @@
 [
     {
+       "from": "demo.html",
+       "to": "demo.html",
+       "method": "GET"
+    },
+    {
+       "from": "lib/:file",
+       "to": "lib/:file",
+       "method": "GET"
+    },
+    {
        "from": "",
        "to": "index.json",
        "method": "GET"
@@ -11,7 +21,7 @@
     },
     {
        "from": "annotations",
-       "to": "../../",
+       "to": "_update/annotation",
        "method": "POST"
     },
     {
@@ -21,7 +31,7 @@
     },
     {
        "from": "annotations/:id",
-       "to": "../../",
+       "to": "_update/annotation",
        "method": "PUT"
     },
     {

--- a/rewrites.json
+++ b/rewrites.json
@@ -36,7 +36,7 @@
     },
     {
        "from": "annotations/:id",
-       "to": "../../:id",
+       "to": "_update/annotation/:id",
        "method": "DELETE"
     },
     {

--- a/rewrites.json
+++ b/rewrites.json
@@ -31,12 +31,12 @@
     },
     {
        "from": "annotations/:id",
-       "to": "_update/annotation",
+       "to": "_update/annotation/:id",
        "method": "PUT"
     },
     {
        "from": "annotations/:id",
-       "to": "../../",
+       "to": "../../:id",
        "method": "DELETE"
     },
     {

--- a/rewrites.json
+++ b/rewrites.json
@@ -38,5 +38,14 @@
        "from": "annotations/:id",
        "to": "../../",
        "method": "DELETE"
+    },
+    {
+       "from": "search",
+       "to": "_list/search/annotationsbyUri",
+       "method": "GET",
+       "query": {
+         "key": ":uri",
+         "include_docs": "true"
+       }
     }
 ]

--- a/updates/annotation.js
+++ b/updates/annotation.js
@@ -1,0 +1,38 @@
+function(doc, req) {
+	var resp = {headers: {'Content-Type': 'application/json'}}
+	var data;
+
+	if (req.body.length === 0) {
+		resp.code = 417
+		resp.body = JSON.stringify({error: 'aborted', reason: 'no content'})
+		return [null,resp]
+	}	
+
+	try {
+		data = JSON.parse(req.body)
+	} catch (e) {
+		resp.code = 500
+		resp.body = JSON.stringify({error: 'aborted', reason: 'could not parse content'})
+		return [null,resp]
+	}
+	
+
+	if (!doc) {
+		//create a new annotation
+		doc = data
+		doc._id = doc.id = req.uuid //the bookmarklet expects the property id
+		resp.code = 201
+	} else {
+		//update an annotation
+		for (p in data) {
+			if (p !== '_id' && data.hasOwnProperty(p)) {
+				doc[p] = data[p]
+			}
+		}
+		resp.code = 202
+	}
+	
+	resp.body = JSON.stringify(doc)
+
+	return [doc,resp]
+}

--- a/updates/annotation.js
+++ b/updates/annotation.js
@@ -1,10 +1,16 @@
 function(doc, req) {
 	var resp = {headers: {'Content-Type': 'application/json'}}
-	var data;
+	var data = {}
 
-	if (req.body.length === 0) {
+	if (req.body.length === 0 || req.body === 'undefined') {
 		resp.code = 417
 		resp.body = JSON.stringify({error: 'aborted', reason: 'no content'})
+		return [null,resp]
+	}	
+
+	if (req.id && req.id.length > 0 && !doc) {
+		resp.code = 404
+		resp.body = JSON.stringify({error: 'aborted', reason: 'doc not found'})
 		return [null,resp]
 	}	
 
@@ -23,13 +29,15 @@ function(doc, req) {
 		doc._id = doc.id = req.uuid //the bookmarklet expects the property id
 		resp.code = 201
 	} else {
+		resp.code = 202
 		//update an annotation
 		for (p in data) {
-			if (p !== '_id' && data.hasOwnProperty(p)) {
+			if (p !== '_id' && p !== '_revisions' && data.hasOwnProperty(p)) {
 				doc[p] = data[p]
 			}
 		}
-		resp.code = 202
+		if (req.method === 'DELETE')
+			doc._deleted = true
 	}
 	
 	resp.body = JSON.stringify(doc)

--- a/validate_doc_update.js
+++ b/validate_doc_update.js
@@ -3,7 +3,7 @@ function(newDoc, oldDoc, userCtx, secObj) {
     , is_admin = v.isAdmin()
  
   if (newDoc._deleted === true) {
-    if (is_admin) {
+    if (is_admin || newDoc.user === oldDoc.user) {
       return
     } else {
       v.unauthorized('Only admins may delete other user annotations.')

--- a/validate_doc_update.js
+++ b/validate_doc_update.js
@@ -1,0 +1,19 @@
+function(newDoc, oldDoc, userCtx, secObj) {
+  var v = require("commonjs/validate").init(newDoc, oldDoc, userCtx, secObj)
+    , is_admin = v.isAdmin()
+ 
+  if (newDoc._deleted === true) {
+    if (is_admin) {
+      return
+    } else {
+      v.unauthorized('Only admins may delete other user annotations.')
+    }
+  }
+
+  if (is_admin) return
+
+  v.require('consumer','id','quote','ranges','uri','user')
+  v.unchanged('user')
+  v.unchanged('uri')
+  
+}

--- a/views/annotationsbyUri/map.js
+++ b/views/annotationsbyUri/map.js
@@ -1,0 +1,9 @@
+function(doc) {
+  if (!doc.consumer || doc.consumer !== 'annotateit')
+    return
+  
+  if (!doc.uri || doc.uri.length === 0)
+    return
+
+  emit(doc.uri, null);
+}


### PR DESCRIPTION
The API path /annotations stores and removes annotations along the methods POST, PUT and DELETE. A customised bookmarklet (see README.md) can be used to create and update annotations on every website visited. The README.md explains how to configure the CouchDB to support the bookmarklet CORS requests.

Have fun!
